### PR TITLE
Improve geocoding with zip codes

### DIFF
--- a/vendor-service/src/main/java/com/stillfresh/app/vendorservice/service/GeoLocationService.java
+++ b/vendor-service/src/main/java/com/stillfresh/app/vendorservice/service/GeoLocationService.java
@@ -25,31 +25,39 @@ public class GeoLocationService {
     }
 
     public double[] getCoordinates(String address) {
+        return getCoordinates(address, null);
+    }
+
+    public double[] getCoordinates(String address, String zipCode) {
         try {
-            logger.debug("Attempting to geocode address: {}", address);
-            GeocodingResult[] results = GeocodingApi.geocode(geoApiContext, address).await();
+            String query = address;
+            if (zipCode != null && !zipCode.isBlank()) {
+                query = address + ", " + zipCode;
+            }
+            logger.debug("Attempting to geocode address: {}", query);
+            GeocodingResult[] results = GeocodingApi.geocode(geoApiContext, query).await();
             
             if (results != null && results.length > 0) {
                 double latitude = results[0].geometry.location.lat;
                 double longitude = results[0].geometry.location.lng;
-                logger.debug("Successfully geocoded address: {} -> lat: {}, lng: {}", address, latitude, longitude);
+                logger.debug("Successfully geocoded address: {} -> lat: {}, lng: {}", query, latitude, longitude);
                 return new double[]{latitude, longitude};
             } else {
-                logger.warn("No geocoding results found for address: {}", address);
+                logger.warn("No geocoding results found for address: {}", query);
                 return null;
             }
         } catch (OverQueryLimitException e) {
-            logger.error("Google Maps API quota exceeded for address: {}", address, e);
+            logger.error("Google Maps API quota exceeded for address: {}", query, e);
             throw new RuntimeException("Google Maps API quota exceeded. Please try again later.", e);
         } catch (RequestDeniedException e) {
-            logger.error("Google Maps API request denied for address: {}. Check API key permissions.", address, e);
+            logger.error("Google Maps API request denied for address: {}. Check API key permissions.", query, e);
             throw new RuntimeException("Google Maps API access denied. Please check API key configuration.", e);
         } catch (ApiException e) {
-            logger.error("Google Maps API error for address: {}. Error: {}", address, e.getMessage(), e);
+            logger.error("Google Maps API error for address: {}. Error: {}", query, e.getMessage(), e);
             throw new RuntimeException("Google Maps API error: " + e.getMessage(), e);
         } catch (Exception e) {
-            logger.error("Unexpected error during geocoding for address: {}", address, e);
-            throw new RuntimeException("Failed to fetch coordinates for address: " + address, e);
+            logger.error("Unexpected error during geocoding for address: {}", query, e);
+            throw new RuntimeException("Failed to fetch coordinates for address: " + query, e);
         }
     }
 }

--- a/vendor-service/src/main/java/com/stillfresh/app/vendorservice/service/VendorService.java
+++ b/vendor-service/src/main/java/com/stillfresh/app/vendorservice/service/VendorService.java
@@ -107,7 +107,7 @@ public class VendorService {
         
         // Fetch and assign geo-coordinates with fallback
         try {
-            double[] coordinates = geoLocationService.getCoordinates(vendor.getAddress());
+            double[] coordinates = geoLocationService.getCoordinates(vendor.getAddress(), vendor.getZipCode());
             if (coordinates != null) {
                 vendor.setLatitude(coordinates[0]);
                 vendor.setLongitude(coordinates[1]);
@@ -236,14 +236,10 @@ public class VendorService {
         if (updatedVendor.getUsername() != null) {
             currentVendor.setUsername(updatedVendor.getUsername());
         }
+        boolean addressChanged = false;
         if (updatedVendor.getAddress() != null) {
             currentVendor.setAddress(updatedVendor.getAddress());
-            // Update geo-coordinates if the address changes
-            double[] coordinates = geoLocationService.getCoordinates(updatedVendor.getAddress());
-            if (coordinates != null) {
-                currentVendor.setLatitude(coordinates[0]);
-                currentVendor.setLongitude(coordinates[1]);
-            }
+            addressChanged = true;
         }
         if (updatedVendor.getPhone() != null) {
             currentVendor.setPhone(updatedVendor.getPhone());
@@ -282,10 +278,20 @@ public class VendorService {
         if (updatedVendor.getImageUrl() != null) {
             currentVendor.setImageUrl(updatedVendor.getImageUrl());
         }
+        boolean zipChanged = false;
         if (updatedVendor.getZipCode() != null) {
             currentVendor.setZipCode(updatedVendor.getZipCode());
+            zipChanged = true;
         }
-        
+
+        if (addressChanged || zipChanged) {
+            double[] coordinates = geoLocationService.getCoordinates(currentVendor.getAddress(), currentVendor.getZipCode());
+            if (coordinates != null) {
+                currentVendor.setLatitude(coordinates[0]);
+                currentVendor.setLongitude(coordinates[1]);
+            }
+        }
+
         vendorRepository.save(currentVendor);
         
         eventPublisher.publishUpdateVendorProfileEvent(new UpdateVendorProfileEvent(currentVendor.getUsername(), currentVendor.getEmail(), currentVendor.getPassword(), currentVendor.getRole(), currentVendor.getStatus()));
@@ -404,7 +410,7 @@ public class VendorService {
         vendor.setStatus(Status.INACTIVE);  // Inactive until verified
         
         // Fetch and assign geo-coordinates
-        double[] coordinates = geoLocationService.getCoordinates(vendor.getAddress());
+        double[] coordinates = geoLocationService.getCoordinates(vendor.getAddress(), vendor.getZipCode());
         if (coordinates != null) {
             vendor.setLatitude(coordinates[0]);
             vendor.setLongitude(coordinates[1]);


### PR DESCRIPTION
## Summary
- expand `GeoLocationService.getCoordinates` to accept optional zip codes
- include vendor zip code when geocoding on registration and profile update
- recompute coordinates if address or zip changes

## Testing
- `./mvnw -q test -pl vendor-service` *(fails: unable to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68702abd05a08330923f5f8e2b33eccf